### PR TITLE
Add firebase realtime chat

### DIFF
--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -1,0 +1,6 @@
+VITE_FIREBASE_API_KEY=your-api-key
+VITE_FIREBASE_AUTH_DOMAIN=your-auth-domain
+VITE_FIREBASE_PROJECT_ID=your-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-storage-bucket
+VITE_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+VITE_FIREBASE_APP_ID=your-app-id

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -22,6 +22,7 @@
     "caniuse-lite": "^1.0.30001717",
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
+    "firebase": "^10.12.2",
     "framer-motion": "^12.16.0",
     "langchain": "^0.3.26",
     "lottie-react": "^2.4.1",

--- a/apps/client/src/components/chat/ChatModule.tsx
+++ b/apps/client/src/components/chat/ChatModule.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import { useUser } from '../../context/UserContext';
+import { realtimeChatService } from '../../services/realtimeChat';
+import type { Contact, ChatMessage } from '@self-learning/types';
+
+const ChatModule: React.FC = () => {
+  const { currentUser } = useUser();
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [selected, setSelected] = useState<Contact | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [newContactId, setNewContactId] = useState('');
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    if (!currentUser) return;
+    const unsub = realtimeChatService.listenContacts(currentUser.id, setContacts);
+    return () => unsub();
+  }, [currentUser]);
+
+  useEffect(() => {
+    if (!currentUser || !selected) return;
+    const unsub = realtimeChatService.listenMessages(
+      currentUser.id,
+      selected.id,
+      setMessages,
+    );
+    return () => unsub();
+  }, [currentUser, selected]);
+
+  const send = async () => {
+    if (!currentUser || !selected || !text.trim()) return;
+    await realtimeChatService.sendMessage(currentUser.id, selected.id, text.trim());
+    setText('');
+  };
+
+  const addContact = async () => {
+    if (!currentUser || !newContactId.trim()) return;
+    const contact: Contact = { id: newContactId.trim(), name: newContactId.trim() };
+    await realtimeChatService.addContact(currentUser.id, contact);
+    setNewContactId('');
+  };
+
+  if (!currentUser) return null;
+
+  return (
+    <div className="p-4 border rounded-md bg-white dark:bg-gray-800">
+      <h2 className="text-lg font-semibold mb-2">即時聊天</h2>
+      <div className="flex">
+        <div className="w-1/3 pr-2 border-r">
+          <h3 className="font-medium mb-2">聯絡人</h3>
+          <ul className="space-y-1">
+            {contacts.map(c => (
+              <li key={c.id}>
+                <button
+                  className={`w-full text-left p-1 rounded ${selected?.id === c.id ? 'bg-blue-500 text-white' : 'hover:bg-gray-100 dark:hover:bg-gray-700'}`}
+                  onClick={() => setSelected(c)}
+                >
+                  {c.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-2 flex">
+            <input
+              value={newContactId}
+              onChange={e => setNewContactId(e.target.value)}
+              className="flex-1 border rounded p-1 text-sm"
+              placeholder="聯絡人ID"
+            />
+            <button onClick={addContact} className="ml-1 px-2 bg-blue-500 text-white rounded">
+              新增
+            </button>
+          </div>
+        </div>
+        <div className="flex-1 pl-2">
+          {selected ? (
+            <div className="flex flex-col h-64">
+              <div className="flex-1 overflow-y-auto mb-2 space-y-1">
+                {messages.map(m => (
+                  <div
+                    key={m.id}
+                    className={m.senderId === currentUser.id ? 'text-right' : 'text-left'}
+                  >
+                    <span className="inline-block bg-gray-200 dark:bg-gray-700 rounded px-2 py-1 text-sm">
+                      {m.content}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="flex">
+                <input
+                  value={text}
+                  onChange={e => setText(e.target.value)}
+                  className="flex-1 border rounded p-1 text-sm"
+                  placeholder="輸入訊息"
+                />
+                <button onClick={send} className="ml-1 px-2 bg-blue-500 text-white rounded">
+                  送出
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="text-gray-500">請選擇聯絡人開始聊天</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChatModule;

--- a/apps/client/src/pages/mentor/MentorDashboard.tsx
+++ b/apps/client/src/pages/mentor/MentorDashboard.tsx
@@ -8,6 +8,7 @@ import { TasksBlock } from '../../components/blocks/TasksBlock';
 import { RecentActivitiesBlock } from '../../components/blocks/RecentActivitiesBlock';
 import { text, layout } from '../../styles/tokens';
 import { mockStudents } from '../../mocks/students';
+import ChatModule from '../../components/chat/ChatModule';
 
 // 動態生成日期
 const today = new Date();
@@ -107,6 +108,9 @@ const MentorDashboard: React.FC = () => {
             <RecentActivitiesBlock activities={recentActivities} />
           </section>
         </div>
+      </div>
+      <div className="mt-6">
+        <ChatModule />
       </div>
     </PageLayout>
   );

--- a/apps/client/src/pages/student/StudentDashboard.tsx
+++ b/apps/client/src/pages/student/StudentDashboard.tsx
@@ -4,6 +4,7 @@ import Calendar from '../../components/calendar/Calendar';
 import { Task } from '../../components/tasks/TaskList';
 import ProgressChart from '../../components/progress/ProgressChart';
 import { Check, BookOpen, Clock, FileText } from 'lucide-react';
+import ChatModule from '../../components/chat/ChatModule';
 
 // Mock data for demonstration
 const todayEvents = [
@@ -341,6 +342,9 @@ const StudentDashboard: React.FC = () => {
             </div>
           </section>
         </div>
+      </div>
+      <div className="mt-6">
+        <ChatModule />
       </div>
     </PageLayout>
   );

--- a/apps/client/src/services/firebase.ts
+++ b/apps/client/src/services/firebase.ts
@@ -1,0 +1,14 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/apps/client/src/services/realtimeChat.ts
+++ b/apps/client/src/services/realtimeChat.ts
@@ -1,0 +1,47 @@
+import { collection, addDoc, onSnapshot, query, orderBy, setDoc, doc } from 'firebase/firestore';
+import { db } from './firebase';
+import type { ChatMessage, Contact } from '@self-learning/types';
+
+function conversationId(userA: string, userB: string): string {
+  return [userA, userB].sort().join('_');
+}
+
+export const realtimeChatService = {
+  sendMessage: async (userId: string, contactId: string, content: string) => {
+    const convId = conversationId(userId, contactId);
+    await addDoc(collection(db, 'conversations', convId, 'messages'), {
+      senderId: userId,
+      receiverId: contactId,
+      content,
+      timestamp: Date.now(),
+    });
+  },
+
+  listenMessages: (
+    userId: string,
+    contactId: string,
+    callback: (messages: ChatMessage[]) => void,
+  ) => {
+    const convId = conversationId(userId, contactId);
+    const q = query(
+      collection(db, 'conversations', convId, 'messages'),
+      orderBy('timestamp'),
+    );
+    return onSnapshot(q, snap => {
+      const msgs = snap.docs.map(d => ({ id: d.id, ...(d.data() as ChatMessage) }));
+      callback(msgs);
+    });
+  },
+
+  addContact: async (userId: string, contact: Contact) => {
+    await setDoc(doc(db, 'users', userId, 'contacts', contact.id), contact);
+  },
+
+  listenContacts: (userId: string, callback: (contacts: Contact[]) => void) => {
+    const q = collection(db, 'users', userId, 'contacts');
+    return onSnapshot(q, snap => {
+      const contacts = snap.docs.map(d => ({ id: d.id, ...(d.data() as Contact) }));
+      callback(contacts);
+    });
+  },
+};

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -1,0 +1,13 @@
+export interface Contact {
+  id: string;
+  name: string;
+  avatar?: string;
+}
+
+export interface ChatMessage {
+  id: string;
+  senderId: string;
+  receiverId: string;
+  content: string;
+  timestamp: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
 export * from './planner';
 export * from './student';
-export * from './task'; 
+export * from './task';
+export * from './chat';


### PR DESCRIPTION
## Summary
- add Firebase config and realtime chat service
- define Contact and ChatMessage types
- implement `ChatModule` component
- show chat module on student and mentor dashboards

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841282a9b9483308e64b683a70a8da0