### PR TITLE
Add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Retrieve token for tests
+        run: node tests/test-login.js
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+
+      - name: Run tests
+        run: yarn test
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- add Github Actions workflow to run tests
- generate test token via `node tests/test-login.js`
- run `yarn test` without blocking deploy

## Testing
- `node tests/test-login.js` *(fails: missing env vars)*
- `yarn test` *(fails: missing temp-token.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875bb2599f48330842be5bbcb4866b0